### PR TITLE
clang12 compilation issue

### DIFF
--- a/plf_hive.h
+++ b/plf_hive.h
@@ -52,7 +52,7 @@ namespace plf
 struct hive_limits // for use in block_capacity setting/getting functions and constructors
 {
 	size_t min, max;
-	hive_limits(const size_t minimum, const size_t maximum) noexcept : min(minimum), max(maximum) {}
+	constexpr hive_limits(const size_t minimum, const size_t maximum) noexcept : min(minimum), max(maximum) {}
 };
 
 


### PR DESCRIPTION
On clang12, I get this error:

error: constexpr function's return type 'plf::hive_limits' is not a literal type
        constexpr static inline plf::hive_limits block_capacity_hard_limits() noexcept
note: 'hive_limits' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
struct hive_limits // for use in block_capacity setting/getting functions and constructors

Adding constexpr on the constructor for hive_limits fixes it.
Tested MSVC and Clang.